### PR TITLE
Fixed token refresh logic.

### DIFF
--- a/vircadia_metaverse_v2_api/src/services/tokens/oauth_token/oauth-token.class.ts
+++ b/vircadia_metaverse_v2_api/src/services/tokens/oauth_token/oauth-token.class.ts
@@ -62,7 +62,6 @@ export class AccountFeild extends DatabaseService {
      */
 
     async create(data: any, params?: any): Promise<any> {
-        const loginUser = extractLoggedInUserFromParams(params);
         const accessGrantType = data.grant_type;
         switch (accessGrantType) {
             case 'password': {
@@ -122,8 +121,7 @@ export class AccountFeild extends DatabaseService {
                         {
                             query: {
                                 refreshToken: refreshingToken,
-                                accountId: loginUser.id,
-                            },
+                            }
                         }
                     );
 
@@ -139,7 +137,7 @@ export class AccountFeild extends DatabaseService {
                         ) {
                             // refresh token has not expired and requestor is owner of the token so make new
                             const newToken = await Tokens.createToken(
-                                loginUser.id,
+                                requestingAccount[0].id,
                                 refreshToken[0].scope
                             );
 


### PR DESCRIPTION
It required authentication, but at the same time was not set up to do any authentication. Fixed by removing the requirement, since from what I understand you are supposed to be able to get a new auth token from a refresh token even if the old one is expired. The native interface does not even use the old auth token in this case, metaverse dashboard does however.